### PR TITLE
make build method infallible

### DIFF
--- a/examples/basic_server.rs
+++ b/examples/basic_server.rs
@@ -20,10 +20,7 @@ async fn main() -> std::io::Result<()> {
     // Configure & build the Actix-Web middleware layer
     let mut labels = HashMap::new();
     labels.insert("label1".to_string(), "value1".to_string());
-    let metrics = ActixWebMetricsBuilder::new()
-        .const_labels(labels)
-        .build()
-        .unwrap();
+    let metrics = ActixWebMetricsBuilder::new().const_labels(labels).build();
 
     HttpServer::new(move || {
         App::new()

--- a/examples/configuring_default_metrics.rs
+++ b/examples/configuring_default_metrics.rs
@@ -15,8 +15,7 @@ async fn main() -> std::io::Result<()> {
             ActixWebMetricsConfig::default()
                 .http_requests_duration_seconds_name("my_http_request_duration"),
         )
-        .build()
-        .unwrap();
+        .build();
 
     HttpServer::new(move || {
         App::new()

--- a/examples/custom_metrics.rs
+++ b/examples/custom_metrics.rs
@@ -12,7 +12,7 @@ async fn health() -> HttpResponse {
 async fn main() -> std::io::Result<()> {
     PrometheusBuilder::new().install().unwrap();
 
-    let metrics = ActixWebMetricsBuilder::new().build().unwrap();
+    let metrics = ActixWebMetricsBuilder::new().build();
 
     HttpServer::new(move || {
         App::new()

--- a/examples/prometheus_endpoint.rs
+++ b/examples/prometheus_endpoint.rs
@@ -16,10 +16,7 @@ async fn get_metrics(prometheus: web::Data<PrometheusHandle>) -> HttpResponse {
 async fn main() -> std::io::Result<()> {
     let prometheus = PrometheusBuilder::new().install_recorder().unwrap();
 
-    let metrics = ActixWebMetricsBuilder::new()
-        .exclude("/metrics")
-        .build()
-        .unwrap();
+    let metrics = ActixWebMetricsBuilder::new().exclude("/metrics").build();
 
     HttpServer::new(move || {
         App::new()

--- a/examples/with_cardinality_on_params.rs
+++ b/examples/with_cardinality_on_params.rs
@@ -21,10 +21,7 @@ async fn main() -> std::io::Result<()> {
 
     let mut labels = HashMap::new();
     labels.insert("label1".to_string(), "value1".to_string());
-    let metrics = ActixWebMetricsBuilder::new()
-        .const_labels(labels)
-        .build()
-        .unwrap();
+    let metrics = ActixWebMetricsBuilder::new().const_labels(labels).build();
 
     HttpServer::new(move || {
         App::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ impl ActixWebMetricsBuilder {
     ///
     /// WARNING: This call purposefully leaks the memory of metrics and label names to avoid
     /// allocations during runtime. Avoid calling more than once.
-    pub fn build(self) -> Result<ActixWebMetrics, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn build(self) -> ActixWebMetrics {
         let namespace_prefix = if let Some(ns) = self.namespace {
             format!("{ns}_")
         } else {
@@ -364,7 +364,7 @@ impl ActixWebMetricsBuilder {
             .collect();
         const_labels.sort_by_key(|v| v.0);
 
-        Ok(ActixWebMetrics {
+        ActixWebMetrics {
             exclude: self.exclude,
             exclude_regex: self.exclude_regex,
             exclude_status: self.exclude_status,
@@ -381,7 +381,7 @@ impl ActixWebMetricsBuilder {
                 version,
                 const_labels,
             },
-        })
+        }
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25,7 +25,7 @@ fn install_debug_recorder() -> Snapshotter {
 async fn middleware_basic() {
     let snapshotter = install_debug_recorder();
 
-    let prometheus = ActixWebMetricsBuilder::new().build().unwrap();
+    let prometheus = ActixWebMetricsBuilder::new().build();
 
     let app = init_service(
         App::new()
@@ -51,8 +51,7 @@ async fn middleware_http_version() {
         .metrics_config(
             ActixWebMetricsConfig::default().labels(LabelsConfig::default().version("version")),
         )
-        .build()
-        .unwrap();
+        .build();
 
     let app = init_service(
         App::new()
@@ -106,7 +105,7 @@ async fn middleware_http_version() {
 async fn middleware_match_pattern() {
     let snapshotter = install_debug_recorder();
 
-    let prometheus = ActixWebMetricsBuilder::new().build().unwrap();
+    let prometheus = ActixWebMetricsBuilder::new().build();
 
     let app = init_service(
         App::new()
@@ -131,8 +130,7 @@ async fn middleware_with_mask_unmatched_pattern() {
 
     let prometheus = ActixWebMetricsBuilder::new()
         .mask_unmatched_patterns("UNKNOWN")
-        .build()
-        .unwrap();
+        .build();
 
     let app = init_service(
         App::new()
@@ -156,7 +154,7 @@ async fn middleware_with_mixed_params_cardinality() {
     let snapshotter = install_debug_recorder();
 
     // we want to keep metrics label on the "cheap param" but not on the "expensive" param
-    let prometheus = ActixWebMetricsBuilder::new().build().unwrap();
+    let prometheus = ActixWebMetricsBuilder::new().build();
 
     let app = init_service(
         App::new().wrap(prometheus).service(
@@ -215,8 +213,7 @@ async fn middleware_basic_failure() {
 
     let prometheus = ActixWebMetricsBuilder::new()
         .disable_unmatched_pattern_masking()
-        .build()
-        .unwrap();
+        .build();
 
     let app = init_service(
         App::new()
@@ -237,7 +234,7 @@ async fn middleware_basic_failure() {
 async fn middleware_custom_counter() {
     let snapshotter = install_debug_recorder();
 
-    let prometheus = ActixWebMetricsBuilder::new().build().unwrap();
+    let prometheus = ActixWebMetricsBuilder::new().build();
 
     let app = init_service(
         App::new()
@@ -269,10 +266,7 @@ async fn middleware_const_labels() {
     let mut labels = HashMap::new();
     labels.insert("label1".to_string(), "value1".to_string());
     labels.insert("label2".to_string(), "value2".to_string());
-    let prometheus = ActixWebMetricsBuilder::new()
-        .const_labels(labels)
-        .build()
-        .unwrap();
+    let prometheus = ActixWebMetricsBuilder::new().const_labels(labels).build();
 
     let app = init_service(
         App::new()
@@ -301,8 +295,7 @@ async fn middleware_metrics_config() {
 
     let prometheus = ActixWebMetricsBuilder::new()
         .metrics_config(metrics_config)
-        .build()
-        .unwrap();
+        .build();
 
     let app = init_service(
         App::new()
@@ -324,21 +317,21 @@ async fn middleware_metrics_config() {
 #[test]
 fn compat_with_non_boxed_middleware() {
     let _app = App::new()
-        .wrap(ActixWebMetricsBuilder::new().build().unwrap())
+        .wrap(ActixWebMetricsBuilder::new().build())
         .wrap(actix_web::middleware::Logger::default())
         .route("", web::to(|| async { "" }));
 
     let _app = App::new()
         .wrap(actix_web::middleware::Logger::default())
-        .wrap(ActixWebMetricsBuilder::new().build().unwrap())
+        .wrap(ActixWebMetricsBuilder::new().build())
         .route("", web::to(|| async { "" }));
 
     let _scope = Scope::new("")
-        .wrap(ActixWebMetricsBuilder::new().build().unwrap())
+        .wrap(ActixWebMetricsBuilder::new().build())
         .route("", web::to(|| async { "" }));
 
     let _resource = Resource::new("")
-        .wrap(ActixWebMetricsBuilder::new().build().unwrap())
+        .wrap(ActixWebMetricsBuilder::new().build())
         .route(web::to(|| async { "" }));
 }
 
@@ -350,8 +343,7 @@ async fn middleware_excludes() {
         .exclude("/ping")
         .exclude_regex("/readyz/.*")
         .exclude_status(StatusCode::NOT_FOUND)
-        .build()
-        .unwrap();
+        .build();
 
     let app = init_service(
         App::new()


### PR DESCRIPTION
The `ActixWebMetricsBuilder::build` method unnecessarily returned a result when it could be infallible. This PR makes the method infallible and updates examples and tests. Note: this is a breaking change.